### PR TITLE
[FixBug] Not updating activity log when creating a brand new account after signing in existing account

### DIFF
--- a/src/components/cards/pagination/PageIndicator.js
+++ b/src/components/cards/pagination/PageIndicator.js
@@ -64,7 +64,7 @@ const PageIndicator = ({ totalPageCount, currentPage, monsterName }) => {
             name="circle"
             size={32}
             color={
-              totalPageCount - currentPage >= 1 && totalPageCount >= 3
+              totalPageCount - currentPage >= 1 && totalPageCount >= 2
                 ? "white"
                 : "transparent"
             }

--- a/src/services/saveActivityData.js
+++ b/src/services/saveActivityData.js
@@ -5,9 +5,7 @@ import {
   retrieveDailyRecord,
   updateDailyRecord,
 } from "../api/dailyRecordService";
-import {
-  resetStreakOrUseHeart,
-} from "./checkChallengeProgress";
+import { resetStreakOrUseHeart } from "./checkChallengeProgress";
 import {
   retrieveChallengeProgressInfo,
   updateChallengeProgress,
@@ -27,7 +25,9 @@ async function saveActivityData(user_id) {
     const activityData = await fetchActivityData();
 
     const isActivityDataSame =
-      previousActivityData && previousActivityData.steps === activityData.steps;
+      previousActivityData &&
+      previousActivityData.steps === activityData.steps &&
+      previousActivityData.userID === user_id;
 
     if (isActivityDataSame) {
       console.log(
@@ -94,7 +94,7 @@ async function saveActivityData(user_id) {
         );
     }
 
-    previousActivityData = activityData;
+    previousActivityData = { ...activityData, userId: user_id };
     return;
   } catch (error) {
     console.error(


### PR DESCRIPTION
[Desc]
- Not updating activity log when creating a brand new account after signing in existing account

[Cause]
- Reading saved activity data in local and checking steps if it matches.
- If the saved steps data is the same as the steps loaded now, app doesn't update steps and UI

[Fix]
- Add another condition (user id) to check previous activity data and current activity data
- Update information in the database except when both steps and user id match the saved steps user id.